### PR TITLE
viewer zIndex made higher than bootstrap navbar

### DIFF
--- a/app/assets/javascripts/hermitage.js.coffee.erb
+++ b/app/assets/javascripts/hermitage.js.coffee.erb
@@ -13,7 +13,7 @@ root.hermitage =
   # Image viewer properties
   default:
     styles:
-      zIndex: 10
+      zIndex: 1010
       position: 'fixed'
       top: 0
       left: 0


### PR DESCRIPTION
looked bad before 
![screenshot at lis 05 10-51-01](https://cloud.githubusercontent.com/assets/1090074/4915646/5c3e4a36-64d1-11e4-9ffd-f545a9b73189.png)
