### PR TITLE
Bootstrap Fixed Nav Zindex Issue

### DIFF
--- a/app/assets/javascripts/hermitage.js.coffee.erb
+++ b/app/assets/javascripts/hermitage.js.coffee.erb
@@ -13,7 +13,7 @@ root.hermitage =
   # Image viewer properties
   default:
     styles:
-      zIndex: 1010
+      zIndex: 1030
       position: 'fixed'
       top: 0
       left: 0
@@ -81,6 +81,7 @@ root.hermitage =
         fontFamily: 'Tahoma,Arial,Helvetica,sans-serif'
         whiteSpace: 'nowrap'
         cursor: 'pointer'
+        padding: '0px 20px'
     styles: {}        
     enabled: true
     text: '×'


### PR DESCRIPTION
The bootstrap sass default [$zindex-navbar-fixed](https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss) is 1030. So, even though my site uses bootstrap - should be fully supported with hermitage out of the box - the image window was always below my default fixed nav, and I couldn't use "x" to close the popover. 

Also, the close "x" being fixed on the top right wasn't the most visually appealing - it blends in with the top right of the browser window. 

Gave it some minimal padding to prevent this effect. 

![image](https://cloud.githubusercontent.com/assets/4473327/6662960/1ac746ea-cbf4-11e4-96fc-383ca4abf3db.png)
